### PR TITLE
fix: use detected language for display instead of patternToLang

### DIFF
--- a/dev-cache/main.go
+++ b/dev-cache/main.go
@@ -758,7 +758,13 @@ func scanDirectory(root string, maxDepth int, patterns []string, patternToLang m
 					f.Err = err.Error()
 				}
 				f.Pattern = pattern
-				f.Language = patternToLang[pattern]
+				// Use detected language when available; patternToLang can be wrong when
+				// multiple languages share a pattern (e.g. node_modules in node, nextjs, vue)
+				if detectLang && detectedLang != "" {
+					f.Language = detectedLang
+				} else {
+					f.Language = patternToLang[pattern]
+				}
 				// Set project root to where language was detected, or parent if no language detection
 				if detectLang && projectRoot != "" {
 					f.ProjectRoot = projectRoot


### PR DESCRIPTION
## Problem

When multiple languages share a pattern (e.g. `node_modules` in node, nextjs, vue), the displayed language was taken from `patternToLang[pattern]`. Since each language overwrites the map entry, the last one in the config (vue) always won. This caused Next.js projects to be incorrectly labeled as vue.

## Solution

Use the detected language from project root signatures when available, falling back to `patternToLang` only when language detection is disabled or no language was detected.

## Example

Before: `nval-web-app` (Next.js project with `next.config.js`) was shown as **vue**
After: correctly shown as **nextjs**