### PR TITLE
Add Linux support to install.sh and release builds for dev-cache/git-cleaner

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
       - arm64
@@ -38,6 +39,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
       - arm64
@@ -68,7 +70,7 @@ builds:
 archives:
   # Combined tarball for Homebrew
   - id: cache-cleaner
-    name_template: "cache-cleaner-{{ .Version }}-darwin-{{ .Arch }}"
+    name_template: "cache-cleaner-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     files:
       - none*  # Only include binaries, no extra files
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ This installs all 3 apps: `dev-cache`, `git-cleaner`, and `mac-cache-cleaner`.
 If you don't have Homebrew, you can use the install script:
 
 ```bash
-# Install all 3 apps to ~/.local/bin
+# Install all available apps for your OS to ~/.local/bin
+# - macOS: dev-cache, git-cleaner, mac-cache-cleaner
+# - Linux: dev-cache, git-cleaner
 curl -sSfL https://raw.githubusercontent.com/markcallen/cache-cleaner/HEAD/install.sh | sh -s -- -b $HOME/.local/bin
 
 # Install specific app only
@@ -55,7 +57,9 @@ Add this to your shell profile (`~/.zshrc` or `~/.bashrc`) to make it permanent.
 
 - The script installs from the latest GitHub release archives.
 - `-b <dir>` is mandatory and determines where binaries are written.
-- Use `-a <app>` to install a single binary (`dev-cache`, `git-cleaner`, or `mac-cache-cleaner`); omit `-a` to install all three.
+- Supported OS values are `darwin` and `linux`.
+- Use `-a <app>` to install a single binary (`dev-cache`, `git-cleaner`, or `mac-cache-cleaner`).
+- On Linux, default install includes `dev-cache` and `git-cleaner`; `mac-cache-cleaner` is macOS-only.
 - The script exits early with an error (without partial installs) if required flags or tools are missing.
 
 ## Quick Start
@@ -179,7 +183,8 @@ git push origin v1.0.0
 
 1. GitHub Actions will trigger the release workflow
 2. GoReleaser will:
-   - Build all 3 binaries for darwin/amd64 and darwin/arm64
+   - Build `dev-cache` and `git-cleaner` for darwin+linux (amd64 and arm64)
+   - Build `mac-cache-cleaner` for darwin (amd64 and arm64)
    - Create a GitHub release with binaries attached
    - Generate a Homebrew cask
    - Push the formula to `homebrew-cache-cleaner` repository

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Add this to your shell profile (`~/.zshrc` or `~/.bashrc`) to make it permanent.
 
 #### install.sh behavior
 
-- The script installs from the latest GitHub release archives.
+- The script downloads the latest GitHub release binaries from `releases/download` assets.
 - `-b <dir>` is mandatory and determines where binaries are written.
 - Supported OS values are `darwin` and `linux`.
 - Use `-a <app>` to install a single binary (`dev-cache`, `git-cleaner`, or `mac-cache-cleaner`).
 - On Linux, default install includes `dev-cache` and `git-cleaner`; `mac-cache-cleaner` is macOS-only.
-- The script exits early with an error (without partial installs) if required flags or tools are missing.
+- The script exits early with an error if required flags or tools are missing; when installing multiple apps, a failure part-way through may leave earlier apps installed.
 
 ## Quick Start
 

--- a/install.sh
+++ b/install.sh
@@ -147,43 +147,42 @@ case "$VERSION" in
   *) error "version must be a semver tag like v1.2.3" ;;
 esac
 
+# Require tools
+command -v curl >/dev/null 2>&1 || error "curl is required"
+command -v tar >/dev/null 2>&1 || error "tar is required"
+
 # Cleanup function for temp files
 cleanup() {
-  if [ -n "${TMPFILE:-}" ] && [ -f "$TMPFILE" ]; then
-    rm -f "$TMPFILE"
+  if [ -n "${TMPDIR:-}" ] && [ -d "$TMPDIR" ]; then
+    rm -rf "$TMPDIR"
   fi
 }
 trap cleanup EXIT INT HUP TERM
 
-# Install each app
+VERSION_NO_V="$(printf "%s" "$VERSION" | sed 's/^v//')"
+ARCHIVE_NAME="cache-cleaner-${VERSION_NO_V}-${OS}-${ARCH}.tar.gz"
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${VERSION}/${ARCHIVE_NAME}"
+
+TMPDIR="$(mktemp -d -t cache-cleaner.XXXXXX)"
+ARCHIVE_PATH="${TMPDIR}/${ARCHIVE_NAME}"
+STAGE_DIR="${TMPDIR}/stage"
+mkdir -p "$STAGE_DIR"
+
+printf "Downloading %s for %s/%s\n" "$ARCHIVE_NAME" "$OS" "$ARCH"
+curl -fL "${DOWNLOAD_URL}" -o "$ARCHIVE_PATH" || error "download failed: ${DOWNLOAD_URL}"
+
+tar -xzf "$ARCHIVE_PATH" -C "$STAGE_DIR" || error "failed to extract ${ARCHIVE_NAME}"
+
+mkdir -p "$BIN_DIR"
 for APP_NAME in $APPS; do
-  ASSET_NAME="${APP_NAME}-${OS}-${ARCH}"
-  DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${VERSION}/${ASSET_NAME}"
-
-  TMPFILE="$(mktemp -t ${APP_NAME}.XXXXXX)"
-
+  SRC="${STAGE_DIR}/${APP_NAME}"
+  DEST="${BIN_DIR}/${APP_NAME}"
+  [ -f "$SRC" ] || error "release archive missing binary: ${APP_NAME}"
+  chmod 0755 "$SRC"
   printf "Installing %s %s for %s/%s to %s\n" "$APP_NAME" "$VERSION" "$OS" "$ARCH" "$BIN_DIR"
-
-  curl -fL "${DOWNLOAD_URL}" -o "$TMPFILE" || error "download failed: ${DOWNLOAD_URL}"
-
-  chmod 0755 "$TMPFILE"
-  mkdir -p "$BIN_DIR"
-  DEST="$BIN_DIR/${APP_NAME}"
-
-  if mv "$TMPFILE" "$DEST" 2>/dev/null; then
-    # Successfully moved, clear TMPFILE so cleanup doesn't try to remove it
-    TMPFILE=""
-  else
-    # Try install to handle cross-filesystem permissions
-    if install -m 0755 "$TMPFILE" "$DEST" 2>/dev/null; then
-      # Successfully installed, remove temp file since install copies it
-      rm -f "$TMPFILE"
-      TMPFILE=""
-    else
-      error "failed to install to $DEST (try with sudo or set -b)"
-    fi
+  if ! install -m 0755 "$SRC" "$DEST" 2>/dev/null; then
+    error "failed to install to $DEST (try with sudo or set -b)"
   fi
-
   printf "Installed: %s\n" "$DEST"
   "$DEST" --version >/dev/null 2>&1 || true
 done


### PR DESCRIPTION
## Summary
- Extend `install.sh` OS detection to support both `darwin` and `linux`
- Install OS-appropriate defaults (`dev-cache` + `git-cleaner` on Linux; all three on macOS)
- Keep `mac-cache-cleaner` macOS-only with a clear Linux error
- Use `${OS}` in release asset download naming in `install.sh`
- Build `dev-cache` and `git-cleaner` for Linux in GoReleaser
- Update root README install/release docs to reflect OS-specific behavior

## Issues
- Closes #19

## Validation
- `sh -n install.sh`
- `make test`
